### PR TITLE
Fix spurious tuple element breaking nf-tests on latest-everything

### DIFF
--- a/subworkflows/local/fastq_fastqc_umitools_trimmomatic/tests/main.nf.test
+++ b/subworkflows/local/fastq_fastqc_umitools_trimmomatic/tests/main.nf.test
@@ -33,8 +33,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -133,8 +132,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -185,8 +183,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -235,8 +232,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -287,8 +283,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -339,8 +334,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -394,8 +388,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -448,8 +441,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -503,8 +495,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -556,8 +547,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -597,8 +587,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -638,8 +627,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -680,8 +668,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -721,8 +708,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -762,8 +748,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -815,8 +800,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -858,8 +842,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi
@@ -902,8 +885,7 @@ nextflow_workflow {
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ],
-                    []
+                    ]
                 ])
                 input[1] = params.skip_fastqc
                 input[2] = params.with_umi


### PR DESCRIPTION
Fixes the `latest-everything` CI leg.

## What was wrong

`FASTQ_FASTQC_UMITOOLS_TRIMMOMATIC` declares `ch_reads` as `[ val(meta), [ reads ] ]` and `FASTQC` declares `tuple val(meta), path(reads)`, but every `input[0]` in its test supplied a **third** element:

```groovy
input[0] = Channel.of([
    [ id:'test', single_end:false ],
    [ file(test_1.fastq.gz), file(test_2.fastq.gz) ],
    []                                              // <-- spurious
])
```

Nextflow 25.10.4 tolerates this and only logs `WARN: Input tuple does not match tuple declaration` — which is why it has been sitting in the logs unnoticed. Nextflow 26.08.0-edge, which `latest-everything` currently resolves to, **aborts the run** instead, producing a bare `Execution aborted due to an unexpected error` with no detail.

## Verification

Removed all 18 occurrences and ran the whole file locally under `NXF_VER=26.08.0-edge`:

```
SUCCESS: Executed 19 tests in 297.254s
```

19/19 pass, including the two that fail in CI (`sarscov2 paired-end [fastq]` and `save_trimmed_fail - stub`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
